### PR TITLE
Add EntityMapper for SQLInsertClause.populate()

### DIFF
--- a/src/main/java/pl/exsio/querydsl/entityql/mapper/EntityMapper.java
+++ b/src/main/java/pl/exsio/querydsl/entityql/mapper/EntityMapper.java
@@ -39,11 +39,11 @@ public class EntityMapper implements Mapper<Object> {
     @Override
     public Map<Path<?>, Object> createMap(RelationalPath<?> path, Object object) {
         try {
-            Map<String, Path<?>> columnToPath = new HashMap<String, Path<?>>();
+            Map<String, Path<?>> columnToPath = new HashMap<>();
             for (Path<?> column : path.getColumns()) {
                 columnToPath.put(ColumnMetadata.getName(column), column);
             }
-            Map<Path<?>, Object> values = new HashMap<Path<?>, Object>();
+            Map<Path<?>, Object> values = new HashMap<>();
             for (Field field : ReflectionUtils.getFields(object.getClass())) {
                 Column ann = field.getAnnotation(Column.class);
                 if (ann != null) {

--- a/src/main/java/pl/exsio/querydsl/entityql/mapper/EntityMapper.java
+++ b/src/main/java/pl/exsio/querydsl/entityql/mapper/EntityMapper.java
@@ -17,6 +17,7 @@ import java.util.Map;
  * For <code>SQLInsertClause.populate()</code> <br/>
  * Creates the mapping via <code>javax.persistence.Column</code> annotated fields in the object.<br/>
  * Field names don't have to match those in the RelationalPath.
+ *
  * @author jojoldu
  */
 public class EntityMapper implements Mapper<Object> {

--- a/src/main/java/pl/exsio/querydsl/entityql/mapper/EntityMapper.java
+++ b/src/main/java/pl/exsio/querydsl/entityql/mapper/EntityMapper.java
@@ -27,10 +27,6 @@ public class EntityMapper implements Mapper<Object> {
 
     private final boolean withNullBindings;
 
-    public EntityMapper() {
-        this(false);
-    }
-
     public EntityMapper(boolean withNullBindings) {
         this.withNullBindings = withNullBindings;
     }

--- a/src/main/java/pl/exsio/querydsl/entityql/mapper/EntityMapper.java
+++ b/src/main/java/pl/exsio/querydsl/entityql/mapper/EntityMapper.java
@@ -1,0 +1,66 @@
+package pl.exsio.querydsl.entityql.mapper;
+
+import com.querydsl.core.QueryException;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.util.ReflectionUtils;
+import com.querydsl.sql.ColumnMetadata;
+import com.querydsl.sql.RelationalPath;
+import com.querydsl.sql.dml.Mapper;
+import com.querydsl.sql.types.Null;
+
+import javax.persistence.Column;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * For <code>SQLInsertClause.populate()</code> <br/>
+ * Creates the mapping via <code>javax.persistence.Column</code> annotated fields in the object.<br/>
+ * Field names don't have to match those in the RelationalPath.
+ * @author jojoldu
+ */
+public class EntityMapper implements Mapper<Object> {
+    public static final EntityMapper DEFAULT = new EntityMapper(false);
+
+    public static final EntityMapper WITH_NULL_BINDINGS = new EntityMapper(true);
+
+    private final boolean withNullBindings;
+
+    public EntityMapper() {
+        this(false);
+    }
+
+    public EntityMapper(boolean withNullBindings) {
+        this.withNullBindings = withNullBindings;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
+    public Map<Path<?>, Object> createMap(RelationalPath<?> path, Object object) {
+        try {
+            Map<String, Path<?>> columnToPath = new HashMap<String, Path<?>>();
+            for (Path<?> column : path.getColumns()) {
+                columnToPath.put(ColumnMetadata.getName(column), column);
+            }
+            Map<Path<?>, Object> values = new HashMap<Path<?>, Object>();
+            for (Field field : ReflectionUtils.getFields(object.getClass())) {
+                Column ann = field.getAnnotation(Column.class);
+                if (ann != null) {
+                    field.setAccessible(true);
+                    Object propertyValue = field.get(object);
+                    if (propertyValue != null) {
+                        if (columnToPath.containsKey(ann.name())) {
+                            values.put(columnToPath.get(ann.name()), propertyValue);
+                        }
+                    } else if (withNullBindings) {
+                        values.put(columnToPath.get(ann.name()), Null.DEFAULT);
+                    }
+                }
+            }
+            return values;
+        } catch (IllegalAccessException e) {
+            throw new QueryException(e);
+        }
+
+    }
+}

--- a/src/test/java/pl/exsio/querydsl/entityql/feature/EntityQLQueryFeature.java
+++ b/src/test/java/pl/exsio/querydsl/entityql/feature/EntityQLQueryFeature.java
@@ -1,0 +1,25 @@
+package pl.exsio.querydsl.entityql.feature;
+
+import com.querydsl.sql.Configuration;
+import com.querydsl.sql.H2Templates;
+import com.querydsl.sql.SQLQueryFactory;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import pl.exsio.querydsl.entityql.benchmark.PerformanceBenchmark;
+import pl.exsio.querydsl.entityql.benchmark.execution.QueryExecutionBenchmark;
+import pl.exsio.querydsl.entityql.config.EntityQlQueryFactory;
+
+import javax.sql.DataSource;
+
+public abstract class EntityQLQueryFeature {
+
+    public static DataSource dataSource() {
+        return new EmbeddedDatabaseBuilder().setType(EmbeddedDatabaseType.H2)
+                .addScript("feature-test-schema.sql")
+                .build();
+    }
+
+    public static SQLQueryFactory queryFactory() {
+        return new EntityQlQueryFactory(new Configuration(new H2Templates()), dataSource());
+    }
+}

--- a/src/test/java/pl/exsio/querydsl/entityql/feature/sql/SQLInsertClauseTest.java
+++ b/src/test/java/pl/exsio/querydsl/entityql/feature/sql/SQLInsertClauseTest.java
@@ -31,7 +31,6 @@ public class SQLInsertClauseTest extends EntityQLQueryFeature {
         queryFactory.insert(qJBook)
                 .populate(target, BeanMapper.DEFAULT)
                 .execute();
-
     }
 
     @Test

--- a/src/test/java/pl/exsio/querydsl/entityql/feature/sql/SQLInsertClauseTest.java
+++ b/src/test/java/pl/exsio/querydsl/entityql/feature/sql/SQLInsertClauseTest.java
@@ -2,6 +2,7 @@ package pl.exsio.querydsl.entityql.feature.sql;
 
 import com.querydsl.sql.SQLQueryFactory;
 import com.querydsl.sql.dml.BeanMapper;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.dao.DataIntegrityViolationException;

--- a/src/test/java/pl/exsio/querydsl/entityql/feature/sql/SQLInsertClauseTest.java
+++ b/src/test/java/pl/exsio/querydsl/entityql/feature/sql/SQLInsertClauseTest.java
@@ -5,12 +5,9 @@ import com.querydsl.sql.dml.BeanMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.dao.DataIntegrityViolationException;
-import pl.exsio.querydsl.entityql.EntityQL;
-import pl.exsio.querydsl.entityql.Q;
 import pl.exsio.querydsl.entityql.dto.BookDto;
 import pl.exsio.querydsl.entityql.feature.EntityQLQueryFeature;
 import pl.exsio.querydsl.entityql.jpa.entity.JBook;
-import pl.exsio.querydsl.entityql.jpa.entity.generated.QJBook;
 import pl.exsio.querydsl.entityql.mapper.EntityMapper;
 
 import static com.querydsl.core.types.Projections.constructor;

--- a/src/test/java/pl/exsio/querydsl/entityql/feature/sql/SQLInsertClauseTest.java
+++ b/src/test/java/pl/exsio/querydsl/entityql/feature/sql/SQLInsertClauseTest.java
@@ -1,0 +1,62 @@
+package pl.exsio.querydsl.entityql.feature.sql;
+
+import com.querydsl.sql.SQLQueryFactory;
+import com.querydsl.sql.dml.BeanMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import pl.exsio.querydsl.entityql.EntityQL;
+import pl.exsio.querydsl.entityql.Q;
+import pl.exsio.querydsl.entityql.dto.BookDto;
+import pl.exsio.querydsl.entityql.feature.EntityQLQueryFeature;
+import pl.exsio.querydsl.entityql.jpa.entity.JBook;
+import pl.exsio.querydsl.entityql.jpa.entity.generated.QJBook;
+import pl.exsio.querydsl.entityql.mapper.EntityMapper;
+
+import static com.querydsl.core.types.Projections.constructor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static pl.exsio.querydsl.entityql.jpa.entity.generated.QJBook.qJBook;
+
+public class SQLInsertClauseTest extends EntityQLQueryFeature {
+    private SQLQueryFactory queryFactory;
+
+    @Before
+    public void setUp() throws Exception {
+        queryFactory = queryFactory();
+    }
+
+    @Test(expected = DataIntegrityViolationException.class)
+    public void throwViolationExceptionIfUsingBeanMapper()  {
+        Long expectedId = 1L;
+        JBook target = new JBook();
+        target.setId(expectedId);
+
+        queryFactory.insert(qJBook)
+                .populate(target, BeanMapper.DEFAULT)
+                .execute();
+
+    }
+
+    @Test
+    public void successInsertIfUsingEntityMapper() throws Exception {
+        Long expectedId = 1L;
+        JBook target = new JBook();
+        target.setId(expectedId);
+
+        queryFactory.insert(qJBook)
+                .populate(target, EntityMapper.DEFAULT)
+                .execute();
+
+        BookDto result = queryFactory
+                .select(constructor(BookDto.class,
+                        qJBook.longNumber("id"),
+                        qJBook.string("name"),
+                        qJBook.string("desc"),
+                        qJBook.decimalNumber("price")
+                ))
+                .from(qJBook)
+                .fetchOne();
+
+        assertThat(result.getId()).isEqualTo(expectedId);
+    }
+}

--- a/src/test/java/pl/exsio/querydsl/entityql/mapper/EntityMapperTest.java
+++ b/src/test/java/pl/exsio/querydsl/entityql/mapper/EntityMapperTest.java
@@ -1,0 +1,39 @@
+package pl.exsio.querydsl.entityql.mapper;
+
+
+import com.querydsl.core.types.Path;
+import com.querydsl.sql.dml.BeanMapper;
+import org.junit.Test;
+import pl.exsio.querydsl.entityql.jpa.entity.JBook;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static pl.exsio.querydsl.entityql.jpa.entity.generated.QJBook.qJBook;
+
+public class EntityMapperTest {
+
+    @Test
+    public void notSearchPropertyIfUsingBeanMapper() throws Exception {
+        Long expectedId = 1L;
+        JBook obj = new JBook();
+        obj.setId(expectedId);
+
+        BeanMapper mapper = BeanMapper.DEFAULT;
+        Map<Path<?>, Object> result = mapper.createMap(qJBook, obj);
+
+        assertThat(result.containsValue(expectedId)).isFalse();
+    }
+
+    @Test
+    public void searchPropertyIfUsingBeanMapper() throws Exception {
+        Long expectedId = 1L;
+        JBook obj = new JBook();
+        obj.setId(expectedId);
+
+        EntityMapper mapper = EntityMapper.DEFAULT;
+        Map<Path<?>, Object> result = mapper.createMap(qJBook, obj);
+
+        assertThat(result).containsValue(expectedId);
+    }
+}

--- a/src/test/java/pl/exsio/querydsl/entityql/mapper/EntityMapperTest.java
+++ b/src/test/java/pl/exsio/querydsl/entityql/mapper/EntityMapperTest.java
@@ -3,6 +3,7 @@ package pl.exsio.querydsl.entityql.mapper;
 
 import com.querydsl.core.types.Path;
 import com.querydsl.sql.dml.BeanMapper;
+import com.querydsl.sql.types.Null;
 import org.junit.Test;
 import pl.exsio.querydsl.entityql.jpa.entity.JBook;
 
@@ -35,5 +36,18 @@ public class EntityMapperTest {
         Map<Path<?>, Object> result = mapper.createMap(qJBook, obj);
 
         assertThat(result).containsValue(expectedId);
+    }
+
+    @Test
+    public void nullBindingIfUsingBeanMapper() throws Exception {
+        Long expectedId = 1L;
+        JBook obj = new JBook();
+        obj.setId(expectedId);
+
+        EntityMapper mapper = EntityMapper.WITH_NULL_BINDINGS;
+        Map<Path<?>, Object> result = mapper.createMap(qJBook, obj);
+
+        assertThat(result).containsValue(expectedId);
+        assertThat(result).containsValue(Null.DEFAULT);
     }
 }

--- a/src/test/resources/feature-test-schema.sql
+++ b/src/test/resources/feature-test-schema.sql
@@ -1,2 +1,1 @@
-create table JBOOKS (BOOK_ID bigint not null, DESC CLOB, NAME varchar(255), PRICE decimal(19,2), primary key (BOOK_ID));
-alter table JBOOKS add constraint UK_j5kgaosmuibg20yalaplmf43t unique (NAME);
+create table IF NOT EXISTS JBOOKS (BOOK_ID bigint not null, DESC CLOB, NAME varchar(255), PRICE decimal(19,2), primary key (BOOK_ID));

--- a/src/test/resources/feature-test-schema.sql
+++ b/src/test/resources/feature-test-schema.sql
@@ -1,0 +1,2 @@
+create table JBOOKS (BOOK_ID bigint not null, DESC CLOB, NAME varchar(255), PRICE decimal(19,2), primary key (BOOK_ID));
+alter table JBOOKS add constraint UK_j5kgaosmuibg20yalaplmf43t unique (NAME);


### PR DESCRIPTION
Hi @eXsio 

QClass created with Entityql as below will fail when using ```SQLInsertClause.populate()```.

```java
    @Test
    void sqlPopulateInsert() throws Exception {
        //given
        Book entity = Book.builder()
                .bookNo(1)
                .bookType(BookType.IT)
                .build();

        //when
        sqlQueryFactory.insert(qBook)
                .populate(entity, BeanMapper.DEFAULT)
                .execute();

        //then
        List<Book> results = bookRepository.findAll();
        assertThat(results).hasSize(1);
        assertThat(results.get(0).getId()).isEqualTo(1L);
        assertThat(results.get(0).getBookType()).isEqualTo(BookType.IT);
    }
```

This is the insert query I intended,

```sql
insert into book (book_type, book_no) values (?, ?)
```

Actually, it works like this:

```sql
insert into book values ()
```

The reason was that the property key and the column name were different, and there was an issue that could not be recognized.

In BeanMapper supported by Querydsl-sql, the property key and the column name had to match.

This problem is also recognized in Querydsl-sql, so AnnotationMapper is supported.
However, AnnotationMapper uses the @Column annotation of querydsl, so it cannot be used in QClass created with Entityql.

So I created a Mapper class that uses JPA's @Column annotation.
I changed the test code above to EntityMapper and it worked fine.

Below is a link to the code I tested.

[link](https://github.com/jojoldu/blog-code/blob/6767580a88d357b9acbc30d7ab01aa0d5fb603d4/spring-boot-querydsl/src/test/java/com/jojoldu/blogcode/querydsl/entityql/QuerydslSqlInsertTest.java#L85)

I'll ask for confirmation.